### PR TITLE
Fix contradictory spec

### DIFF
--- a/pg-promise-exercises/exercises.js
+++ b/pg-promise-exercises/exercises.js
@@ -46,7 +46,7 @@ allBooks.then(books => {
            Exercise 2
    -----------------------------------------
 
-   Implement the function `firstTenBooks` which returns just the names of the
+   Implement the function `firstTenBooks` which returns the first ten
    books, and make the assertion pass.
    @function: `firstTenBooks`
    @input params: None


### PR DESCRIPTION
The description said to only return the book title but the `@output` spec includes more.

Changed description.